### PR TITLE
Add auto-collapse toolbar toggle in settings

### DIFF
--- a/src/controls/floating_toolbar.js
+++ b/src/controls/floating_toolbar.js
@@ -5,6 +5,7 @@
  */
 
 import { NavigationTree } from "./navigation_tree.js";
+import { Settings } from "../settings/settings.js";
 
 export class FloatingToolbar {
   /**
@@ -31,6 +32,7 @@ export class FloatingToolbar {
     this.expandTimer = null;
     this.HIDE_DELAY = 3000;
     this.COLLAPSE_DELAY = 7000;
+    this.autoCollapse = Settings.isAutoCollapseEnabled();
 
     this.#scrollCallback = () => this.updatePageNumber();
 
@@ -286,6 +288,7 @@ export class FloatingToolbar {
   }
 
   #startExpandTimer() {
+    if (!this.autoCollapse) return;
     this.#cancelExpandTimer();
     this.expandTimer = setTimeout(() => {
       this.#collapse();
@@ -314,6 +317,20 @@ export class FloatingToolbar {
     if (!this.isHidden) return;
     this.isHidden = false;
     this.wrapper.classList.remove("hidden");
+  }
+
+  /**
+   * @param {boolean} enabled
+   */
+  setAutoCollapse(enabled) {
+    this.autoCollapse = enabled;
+    if (enabled) {
+      if (this.isExpanded) {
+        this.#startExpandTimer();
+      }
+    } else {
+      this.#cancelExpandTimer();
+    }
   }
 
   enterSplitMode() {

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -8,6 +8,8 @@ import { BallEditor } from "./ball_editor.js";
 export class Settings {
   /** @type {string} */
   static PROGRESS_BAR_KEY = "hover_progress_bar_enabled";
+  /** @type {string} */
+  static AUTO_COLLAPSE_KEY = "hover_toolbar_auto_collapse";
 
   /**
    * @param {SplitWindowManager} wm
@@ -85,6 +87,37 @@ export class Settings {
     if (typeof chrome !== "undefined" && chrome.storage?.local) {
       chrome.storage.local.set({
         [Settings.PROGRESS_BAR_KEY]: enabled,
+      });
+    }
+  }
+
+  /**
+   * Check if toolbar auto-collapse is enabled.
+   * @returns {boolean}
+   */
+  static isAutoCollapseEnabled() {
+    try {
+      const val = localStorage.getItem(Settings.AUTO_COLLAPSE_KEY);
+      return val === null ? true : val === "true";
+    } catch {
+      return true;
+    }
+  }
+
+  /**
+   * Save toolbar auto-collapse state.
+   * @param {boolean} enabled
+   */
+  static setAutoCollapseEnabled(enabled) {
+    try {
+      localStorage.setItem(Settings.AUTO_COLLAPSE_KEY, String(enabled));
+    } catch (err) {
+      console.warn("[Settings] Failed to save auto-collapse setting:", err);
+    }
+
+    if (typeof chrome !== "undefined" && chrome.storage?.local) {
+      chrome.storage.local.set({
+        [Settings.AUTO_COLLAPSE_KEY]: enabled,
       });
     }
   }
@@ -249,6 +282,17 @@ export class Settings {
                 <span class="settings-toggle-knob"></span>
               </label>
             </div>
+            <div class="settings-toggle-row">
+              <div class="settings-toggle-info">
+                <span class="settings-toggle-label">Auto-collapse Toolbar</span>
+                <span class="settings-toggle-description">Automatically collapse tool buttons after a delay</span>
+              </div>
+              <label class="settings-toggle-switch">
+                <input type="checkbox" class="auto-collapse-toggle">
+                <span class="settings-toggle-slider"></span>
+                <span class="settings-toggle-knob"></span>
+              </label>
+            </div>
           </div>
 
         </div>
@@ -370,6 +414,18 @@ export class Settings {
           } else {
             this.wm.progressBar.hide();
           }
+        }
+      });
+    }
+
+    // Auto-collapse toggle
+    const collapseToggle = overlay.querySelector(".auto-collapse-toggle");
+    if (collapseToggle) {
+      collapseToggle.checked = Settings.isAutoCollapseEnabled();
+      collapseToggle.addEventListener("change", () => {
+        Settings.setAutoCollapseEnabled(collapseToggle.checked);
+        if (this.wm.toolbar) {
+          this.wm.toolbar.setAutoCollapse(collapseToggle.checked);
         }
       });
     }

--- a/styles/settings.css
+++ b/styles/settings.css
@@ -442,6 +442,10 @@
   border: 1px solid var(--border-color);
 }
 
+.settings-toggle-row + .settings-toggle-row {
+  margin-top: 8px;
+}
+
 .settings-toggle-info {
   display: flex;
   flex-direction: column;
@@ -469,7 +473,7 @@
   align-items: center;
 }
 
-.progress-bar-toggle {
+.settings-toggle-switch input[type="checkbox"] {
   opacity: 0;
   width: 0;
   height: 0;
@@ -500,14 +504,14 @@
   transform: translateY(-50%);
 }
 
-.progress-bar-toggle:checked ~ .settings-toggle-slider {
+.settings-toggle-switch input[type="checkbox"]:checked ~ .settings-toggle-slider {
   background: #fff;
   box-shadow:
     0 0 4px rgba(255, 255, 255, 0.5),
     0 0 10px rgba(255, 255, 255, 0.2);
 }
 
-.progress-bar-toggle:checked ~ .settings-toggle-knob {
+.settings-toggle-switch input[type="checkbox"]:checked ~ .settings-toggle-knob {
   left: 38px;
   border-color: #fff;
   background: #fff;


### PR DESCRIPTION
## Changes

- **FloatingToolbar**: Added `autoCollapse` state and `setAutoCollapse()` method to control automatic toolbar collapse behavior
- **Settings**: Added `AUTO_COLLAPSE_KEY` constant and implemented `isAutoCollapseEnabled()` / `setAutoCollapseEnabled()` methods with localStorage and Chrome storage support
- **Settings UI**: Added new toggle switch for auto-collapse toolbar setting in the settings modal
- **CSS**: Refactored progress bar toggle styles to be generic `.settings-toggle-switch` styles that work for all toggle inputs, and added spacing between toggle rows

## Details

The auto-collapse feature can now be toggled on/off in settings. When disabled, the toolbar will no longer automatically collapse after the delay. The setting persists across sessions via localStorage and Chrome extension storage.